### PR TITLE
Feature: Protocol Handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Visual Studio Code
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[dev-dependencies]
+rstest = "0.18.1"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Redust is a high-performance, open-source, in-memory database server inspired by
 
 1. Clone this repository:
    ```sh
-   git clone https://github.com/SaadKaleem/redust.git
+   git clone https://github.com/SaadKaleem/redust.git &&
    cd redust
    ```
 
@@ -33,6 +33,13 @@ Redust is a high-performance, open-source, in-memory database server inspired by
 3. Run the project:
    ```sh
    cargo run
+   ```
+
+## 🚀 Running the Project
+
+1. Please run the following to run the tests, in /tests dir:
+   ```sh
+   cargo test
    ```
 
 ## 📖 Documentation:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod protocol_handler;
+use protocol_handler::{deserialize_buffer, serialize_data, BulkStringData, RESPType};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/src/protocol_handler.rs
+++ b/src/protocol_handler.rs
@@ -1,0 +1,342 @@
+// The handles the REdis Serialization Protocol parsing for all necessary types.
+use std::fmt;
+
+const MSG_SEPERATOR: &[u8; 2] = b"\r\n";
+const MSG_SEPERATOR_SIZE: usize = MSG_SEPERATOR.len();
+
+#[derive(Debug, PartialEq)]
+pub enum RESPType {
+    SimpleString(String),
+    Error(String),
+    Integer(i32),
+    BulkString(Option<BulkStringData>),
+    Array(Vec<RESPType>),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct BulkStringData {
+    pub text: String,
+    pub prefix_length: usize,
+}
+
+impl fmt::Display for RESPType {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RESPType::SimpleString(response) => response.fmt(fmt),
+            RESPType::Error(msg) => msg.fmt(fmt),
+            RESPType::Integer(num) => num.fmt(fmt),
+            RESPType::BulkString(msg) => write!(fmt, "{:?}", msg),
+            RESPType::Array(parts) => {
+                for (i, part) in parts.iter().enumerate() {
+                    if i > 0 {
+                        // use space as the array element display separator
+                        write!(fmt, " ")?;
+                    }
+
+                    part.fmt(fmt)?;
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
+trait BaseSerializer {
+    const SYMBOL: &'static str;
+
+    /// Default implementation for SimpleString, Error and Integer
+    fn serialize(&self, frame: &RESPType) -> Option<Vec<u8>> {
+        let serialized = format!("{}{}\r\n", self.get_symbol(), frame);
+        Some(serialized.into_bytes())
+    }
+
+    fn deserialize(&self, buffer: &[u8]) -> (Option<RESPType>, usize);
+
+    fn get_symbol(&self) -> &str;
+
+    /// To extract the length prefix for Bulk Strings and Arrays
+    fn extract_length(&self, buffer: &[u8]) -> Option<(i32, usize)> {
+        // Find the position of the first occurence of '\r\n' delimiter
+        let separator: Option<usize> = buffer
+            .windows(2)
+            .position(|window: &[u8]| window == b"\r\n");
+
+        if let Some(crlf_pos) = separator {
+            // Convert the byte slice to a string slice
+            if let Ok(length_str) = std::str::from_utf8(&buffer[1..crlf_pos]) {
+                // Parse the length_str
+                if let Ok(length) = length_str.parse::<i32>() {
+                    return Some((length, crlf_pos));
+                }
+            }
+        }
+        None
+    }
+}
+
+struct SimpleStringSerializer;
+
+impl BaseSerializer for SimpleStringSerializer {
+    const SYMBOL: &'static str = "+";
+
+    fn get_symbol(&self) -> &str {
+        &Self::SYMBOL
+    }
+
+    fn deserialize(&self, buffer: &[u8]) -> (Option<RESPType>, usize) {
+        let separator: Option<usize> = buffer
+            .windows(2)
+            .position(|window: &[u8]| window == b"\r\n");
+
+        if let Some(position) = separator {
+            // The separator was found
+            let payload: String = String::from_utf8_lossy(&buffer[1..position]).to_string();
+            return (Some(RESPType::SimpleString(payload)), position + 2);
+        } else {
+            // The separator was not found
+            return (None, 0);
+        }
+    }
+}
+
+struct ErrorSerializer;
+
+impl BaseSerializer for ErrorSerializer {
+    const SYMBOL: &'static str = "-";
+
+    fn get_symbol(&self) -> &str {
+        &Self::SYMBOL
+    }
+
+    fn deserialize(&self, buffer: &[u8]) -> (Option<RESPType>, usize) {
+        let separator: Option<usize> = buffer
+            .windows(2)
+            .position(|window: &[u8]| window == b"\r\n");
+
+        if let Some(position) = separator {
+            // The separator was found
+            let payload: String = String::from_utf8_lossy(&buffer[1..position]).to_string();
+            return (Some(RESPType::Error(payload)), position + 2);
+        } else {
+            // The separator was not found
+            return (None, 0);
+        }
+    }
+}
+
+struct IntegerSerializer;
+
+impl BaseSerializer for IntegerSerializer {
+    const SYMBOL: &'static str = ":";
+
+    fn get_symbol(&self) -> &str {
+        &Self::SYMBOL
+    }
+
+    fn deserialize(&self, buffer: &[u8]) -> (Option<RESPType>, usize) {
+        let separator: Option<usize> = buffer
+            .windows(2)
+            .position(|window: &[u8]| window == b"\r\n");
+
+        if let Some(position) = separator {
+            // The separator was found
+            let payload: Result<i32, _> = String::from_utf8_lossy(&buffer[1..position]).parse();
+
+            match payload {
+                Ok(integer) => {
+                    return (Some(RESPType::Integer(integer)), position + 2);
+                }
+                Err(_) => {
+                    println!("Failed to parse integer.");
+                    return (None, 0);
+                }
+            }
+        } else {
+            // The separator was not found
+            return (None, 0);
+        }
+    }
+}
+
+struct BulkStringSerializer;
+
+impl BaseSerializer for BulkStringSerializer {
+    const SYMBOL: &'static str = "$";
+
+    fn get_symbol(&self) -> &str {
+        &Self::SYMBOL
+    }
+
+    fn serialize(&self, frame: &RESPType) -> Option<Vec<u8>> {
+        match frame {
+            RESPType::BulkString(values) => match values {
+                Some(data) => {
+                    return Some(
+                        format!(
+                            "{}{}\r\n{}\r\n",
+                            self.get_symbol(),
+                            data.prefix_length,
+                            data.text
+                        )
+                        .into_bytes(),
+                    )
+                }
+                None => return Some(format!("{}{}\r\n", self.get_symbol(), -1).into_bytes()),
+            },
+            _ => return None,
+        };
+    }
+
+    fn deserialize(&self, buffer: &[u8]) -> (Option<RESPType>, usize) {
+        // Found a prefix length, with the start_pos of the 1st CRLF
+        let length_and_pos = self.extract_length(buffer);
+
+        if let Some((prefix_length, crlf_pos)) = length_and_pos {
+            if prefix_length == -1 {
+                return (Some(RESPType::BulkString(None)), 5);
+            } else {
+                let prefix_length_u = prefix_length as usize;
+
+                // Iterate from `crlf_pos + 2` for `prefix_length` iterations, and then
+                // ensure CRLF exists.
+                let start_index: usize = crlf_pos + 2;
+                let end_index: usize = start_index + prefix_length_u;
+
+                // Create a new buffer containing the specified bytes
+                let new_buffer: Vec<u8>;
+                if prefix_length == 0 {
+                    new_buffer = "".as_bytes().to_vec();
+                } else {
+                    new_buffer = buffer[start_index..end_index].to_vec();
+                }
+
+                if new_buffer.len() != prefix_length_u {
+                    return (None, 0);
+                } else {
+                    // Ensure end_index is within bounds
+                    if (end_index + 2) > buffer.len() {
+                        return (None, 0);
+                    }
+
+                    // Verify the two bytes after the end index are CRLF
+                    if buffer[end_index..end_index + 2] != *MSG_SEPERATOR {
+                        return (None, 0);
+                    } else {
+                        // Unwrap to string, and construct the enum
+                        let text = String::from_utf8(new_buffer).unwrap();
+                        let bulk_str_data = BulkStringData {
+                            text,
+                            prefix_length: prefix_length_u,
+                        };
+
+                        return (
+                            Some(RESPType::BulkString(Some(bulk_str_data))),
+                            1 + prefix_length_u.to_string().len()
+                                + MSG_SEPERATOR_SIZE
+                                + prefix_length_u
+                                + MSG_SEPERATOR_SIZE,
+                        );
+                    }
+                }
+            }
+        } else {
+            // Did not find prefix_length and CRLF
+            return (None, 0);
+        }
+    }
+}
+
+struct ArraySerializer;
+
+impl BaseSerializer for ArraySerializer {
+    const SYMBOL: &'static str = "*";
+
+    fn get_symbol(&self) -> &str {
+        &Self::SYMBOL
+    }
+
+    fn serialize(&self, frame: &RESPType) -> Option<Vec<u8>> {
+        match frame {
+            RESPType::Array(vec) => {
+                // Define a mutable buffer to return
+                let mut buffer: Vec<u8> = self.get_symbol().as_bytes().to_vec();
+
+                // Convert the vector length to a string, and then to ascii respresentation
+                let vec_length = vec.len().to_string();
+                let arr_length_ascii = vec_length.as_bytes();
+                buffer.extend(arr_length_ascii);
+
+                // Add the seperator
+                buffer.extend(MSG_SEPERATOR);
+
+                // Serialize the data for children items, within the Array.
+                for item in vec {
+                    let result = serialize_data(item);
+                    match result {
+                        Some(child_payload) => buffer.extend(child_payload),
+                        None => return None,
+                    }
+                }
+
+                return Some(buffer);
+            }
+            _ => return None,
+        };
+    }
+
+    fn deserialize(&self, buffer: &[u8]) -> (Option<RESPType>, usize) {
+        // Found a prefix length, with the start_pos of the 1st CRLF
+        let length_and_pos = self.extract_length(buffer);
+
+        if let Some((array_length, crlf_pos)) = length_and_pos {
+            if array_length == 0 {
+                return (Some(RESPType::Array(Vec::new())), 2 + MSG_SEPERATOR_SIZE);
+            } else {
+                // Iterate from `crlf_pos + 2` for `array_length` iterations
+                let mut next_index: usize = crlf_pos + 2;
+
+                let mut vec: Vec<RESPType> = Vec::new();
+
+                for _ in 0..array_length {
+                    let (result, length) = deserialize_buffer(&buffer[next_index..]);
+                    match result {
+                        Some(child_payload) => vec.push(child_payload),
+                        None => return (None, 0),
+                    }
+                    next_index = next_index + length;
+                }
+                (Some(RESPType::Array(vec)), next_index)
+            }
+        } else {
+            // Did not find prefix_length and CRLF
+            return (None, 0);
+        }
+    }
+}
+
+pub fn deserialize_buffer(input_buf: &[u8]) -> (Option<RESPType>, usize) {
+    if let Some(&first_byte) = input_buf.first() {
+        match first_byte {
+            b'+' => SimpleStringSerializer.deserialize(&input_buf),
+            b'-' => ErrorSerializer.deserialize(&input_buf),
+            b':' => IntegerSerializer.deserialize(&input_buf),
+            b'$' => BulkStringSerializer.deserialize(&input_buf),
+            b'*' => ArraySerializer.deserialize(&input_buf),
+            _ => (None, 0),
+        }
+    } else {
+        // Handle the case when the buffer is empty
+        (None, 0)
+    }
+}
+
+pub fn serialize_data(input_data: &RESPType) -> Option<Vec<u8>> {
+    match input_data {
+        RESPType::SimpleString(_) => SimpleStringSerializer.serialize(&input_data),
+        RESPType::Error(_) => ErrorSerializer.serialize(&input_data),
+        RESPType::Integer(_) => IntegerSerializer.serialize(&input_data),
+        RESPType::BulkString(_) => BulkStringSerializer.serialize(&input_data),
+        RESPType::Array(_) => ArraySerializer.serialize(&input_data)
+    }
+}

--- a/tests/test_protocol_handler.rs
+++ b/tests/test_protocol_handler.rs
@@ -1,0 +1,99 @@
+use redust::protocol_handler::{deserialize_buffer, serialize_data, BulkStringData, RESPType};
+use rstest::rstest;
+
+#[rstest]
+// Simple String Cases
+#[case(b"+PING", (None, 0usize))]
+#[case(b"+OK\r\n", (Some(RESPType::SimpleString("OK".to_string())), 5usize))]
+#[case(b"+OK\r\n+Next", (Some(RESPType::SimpleString("OK".to_string())), 5usize))]
+// Error Test Cases
+#[case(b"-ERR", (None, 0usize))]
+#[case(b"-ERR\r\n", (Some(RESPType::Error("ERR".to_string())), 6usize))]
+#[case(b"-ERR\r\n+Partial", (Some(RESPType::Error("ERR".to_string())), 6usize))]
+// Integer Test Cases
+#[case(b":20", (None, 0usize))]
+#[case(b":20\r\n", (Some(RESPType::Integer(20)), 5usize))]
+#[case(b":20\r\n+PING", (Some(RESPType::Integer(20)), 5usize))]
+// Bulk String Test Cases
+#[case(b"$5\r\nhello", (None, 0usize))]
+#[case(b"$0\r\n\r\n", (Some(RESPType::BulkString(Some(BulkStringData{text: "".to_string(), prefix_length: 0}))), 6usize))]
+#[case(b"$-1\r\n", (Some(RESPType::BulkString(None)), 5usize))]
+#[case(b"$4\r\ntest\r\n", (Some(RESPType::BulkString(Some(BulkStringData{text: "test".to_string(), prefix_length: 4}))), 10usize))]
+#[case(b"$4\r\ntest\r\n+Next", (Some(RESPType::BulkString(Some(BulkStringData{text: "test".to_string(), prefix_length: 4}))), 10usize))]
+// Array Test Cases
+#[case(b"*0", (None, 0usize))]
+#[case(b"*0\r\n", (Some(RESPType::Array(vec![])),4usize))]
+#[case(b"*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n", (Some(RESPType::Array(
+vec![
+    RESPType::BulkString(Some(BulkStringData{text: "hello".to_string(), prefix_length: 5})),
+    RESPType::BulkString(Some(BulkStringData{text: "world".to_string(), prefix_length: 5}))
+    ])),
+    26usize)
+)]
+#[case(b"*2\r\n*2\r\n+Hello\r\n$5\r\nWorld\r\n*3\r\n:1\r\n:2\r\n:3\r\n", (Some(RESPType::Array(
+    vec![
+        RESPType::Array(
+            vec![
+                RESPType::SimpleString("Hello".to_string()),
+                RESPType::BulkString(Some(BulkStringData{text: "World".to_string(), prefix_length: 5}))]
+        ),
+        RESPType::Array(
+            vec![
+                RESPType::Integer(1),
+                RESPType::Integer(2),
+                RESPType::Integer(3)
+                ]
+        )
+        ])),
+        43usize)
+)]
+
+fn deserialize_test(#[case] input: &[u8], #[case] expected: (Option<RESPType>, usize)) {
+    let actual: (Option<RESPType>, usize) = deserialize_buffer(input);
+    assert_eq!(expected.0, actual.0);
+    assert_eq!(expected.1, actual.1);
+}
+
+#[rstest]
+// Simple String Cases
+#[case(RESPType::SimpleString("".to_string()), Some(b"+\r\n".to_vec()))]
+#[case(RESPType::SimpleString("OK".to_string()), Some(b"+OK\r\n".to_vec()))]
+// Error Test Cases
+#[case(RESPType::Error("".to_string()), Some(b"-\r\n".to_vec()))]
+#[case(RESPType::Error("ERR".to_string()), Some(b"-ERR\r\n".to_vec()))]
+// Integer Test Cases
+#[case(RESPType::Integer(-1), Some(b":-1\r\n".to_vec()))]
+#[case(RESPType::Integer(20), Some(b":20\r\n".to_vec()))]
+// Bulk String Test Cases
+#[case(RESPType::BulkString(Some(BulkStringData{text: "".to_string(), prefix_length: 0})), Some(b"$0\r\n\r\n".to_vec()))]
+#[case(RESPType::BulkString(None), Some(b"$-1\r\n".to_vec()))]
+#[case(RESPType::BulkString(Some(BulkStringData{text: "test".to_string(), prefix_length: 4})), Some(b"$4\r\ntest\r\n".to_vec()))]
+// Array Test Cases
+#[case(RESPType::Array(
+    vec![
+        RESPType::BulkString(Some(BulkStringData{text: "hello".to_string(), prefix_length: 5})),
+        RESPType::BulkString(Some(BulkStringData{text: "world".to_string(), prefix_length: 5}))
+        ]), 
+        Some(b"*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n".to_vec())
+)]
+#[case(RESPType::Array(
+    vec![
+        RESPType::Array(
+            vec![
+                RESPType::SimpleString("Hello".to_string()),
+                RESPType::BulkString(Some(BulkStringData{text: "World".to_string(), prefix_length: 5}))]
+        ),
+        RESPType::Array(
+            vec![
+                RESPType::Integer(1),
+                RESPType::Integer(2),
+                RESPType::Integer(3)
+                ]
+        )
+        ]),
+        Some(b"*2\r\n*2\r\n+Hello\r\n$5\r\nWorld\r\n*3\r\n:1\r\n:2\r\n:3\r\n".to_vec())
+)]
+fn serialize_test(#[case] data: RESPType, #[case] expected: Option<Vec<u8>>) {
+    let actual: Option<Vec<u8>> = serialize_data(&data);
+    assert_eq!(expected, actual);
+}


### PR DESCRIPTION
This PR introduces serializers for the [RESP Protocol](https://redis.io/docs/reference/protocol-spec/)

The following types are supported can now be serialized and deserialized:

- Simple Strings
- Error
- Integer
- Bulk Strings
- Array
   - Mixed types
   - Nested array

Unit tests have been parametrized via [rstest](https://github.com/la10736/rstest)
