### PR TITLE
Feature: Duration Parsing for SET + Key Expiration Algorithm + Tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ chrono = { version = "0.4.26" }
 async-trait = "0.1.73"
 mockall = "0.11.4"
 predicates = "2.1.5"
+rand = "0.8.5"
 
 [dev-dependencies]
 rstest = "0.18.1"

--- a/src/cmd/set.rs
+++ b/src/cmd/set.rs
@@ -49,7 +49,9 @@ impl Set {
     /// Parsing the necessary arguments for the `Set` command
     ///
     /// Syntax:
-    /// SET key value [NX | XX] [GET]
+    /// SET key value [NX | XX] [GET] [EX seconds | PX milliseconds |
+    ///    EXAT unix-time-seconds | PXAT unix-time-milliseconds]
+    ///
     pub fn parse(cmd_strings: Vec<String>) -> Result<Set, ParseError> {
         if cmd_strings.len() < 3 {
             return Err(ParseError::SyntaxError(

--- a/src/cmd/set.rs
+++ b/src/cmd/set.rs
@@ -191,12 +191,12 @@ impl Set {
                             "PX" => *duration = Some(Duration::milliseconds(time_value)),
                             "EXAT" => {
                                 // Get the diff from now, and set the duration
-                                let diff_seconds = Utc::now().timestamp() - time_value;
+                                let diff_seconds = time_value - Utc::now().timestamp();
                                 *duration = Some(Duration::seconds(diff_seconds))
                             }
                             "PXAT" => {
                                 // Convert to seconds, and then assign the duration
-                                let diff_seconds = Utc::now().timestamp() - (time_value / 1000);
+                                let diff_seconds = (time_value / 1000) - Utc::now().timestamp();
                                 *duration = Some(Duration::seconds(diff_seconds))
                             }
                             _ => {}

--- a/src/cmd/set.rs
+++ b/src/cmd/set.rs
@@ -1,4 +1,4 @@
-use chrono::Duration;
+use chrono::{Duration, Utc};
 
 use crate::cmd::ParseError;
 use crate::protocol_handler::BulkStringData;
@@ -60,17 +60,22 @@ impl Set {
         } else {
             let key: String = cmd_strings[1].clone();
             let value: DataType = DataType::String(cmd_strings[2].clone());
+            let mut duration: Option<Duration> = None;
 
             let mut nx_flag: bool = false;
             let mut xx_flag: bool = false;
             let mut get_flag: bool = false;
 
-            for cmd in cmd_strings.iter().skip(3) {
-                match cmd.as_str() {
-                    "NX" | "XX" => match Self::parse_nx_or_xx(cmd, &mut nx_flag, &mut xx_flag) {
-                        Ok(_) => {}
-                        Err(err) => return Err(err),
-                    },
+            let mut iterator = cmd_strings.iter().skip(3);
+
+            while let Some(cmd_arg) = iterator.next() {
+                match cmd_arg.as_str() {
+                    "NX" | "XX" => {
+                        match Self::parse_nx_or_xx(cmd_arg, &mut nx_flag, &mut xx_flag) {
+                            Ok(_) => {}
+                            Err(err) => return Err(err),
+                        }
+                    }
                     "GET" => {
                         if get_flag == true {
                             return Err(ParseError::SyntaxError("syntax error".to_string()));
@@ -79,13 +84,24 @@ impl Set {
                         }
                     }
                     "EX" | "PX" | "EXAT" | "PXAT" => {
-                        todo!()
+                        // Get the next iterator value, and also check if it parses properly.
+                        match iterator.next() {
+                            None => {
+                                return Err(ParseError::SyntaxError("syntax error".to_string()))
+                            }
+                            Some(next_arg) => {
+                                match Self::parse_duration_args(cmd_arg, next_arg, &mut duration) {
+                                    Ok(_) => {}
+                                    Err(err) => return Err(err),
+                                }
+                            }
+                        }
                     }
                     _ => {}
                 }
             }
 
-            Ok(Set::new(key, value, None, nx_flag, xx_flag, get_flag))
+            Ok(Set::new(key, value, duration, nx_flag, xx_flag, get_flag))
         }
     }
 
@@ -146,6 +162,49 @@ impl Set {
                 *xx_flag = true;
             }
             return Ok(());
+        }
+    }
+
+    /// Helper method to parse the duration arguments
+    ///
+    /// `cmd_arg` would be the EX | PX | EXAT | PXAT in our case.
+    /// `next_arg` must be a parsable integer.
+    fn parse_duration_args(
+        cmd_arg: &String,
+        next_arg: &String,
+        duration: &mut Option<Duration>,
+    ) -> Result<(), ParseError> {
+        match duration {
+            // If duration is already set, we obviously need to throw a syntax error.
+            Some(_) => Err(ParseError::SyntaxError(format!("{} syntax error", cmd_arg))),
+            None => {
+                // Parse the next argument, to see if it fulfils an i64.
+                let time_value = next_arg.parse::<i64>();
+
+                match time_value {
+                    Err(_) => {
+                        return Err(ParseError::SyntaxError(format!("{} syntax error", cmd_arg)));
+                    }
+                    Ok(time_value) => {
+                        match cmd_arg.as_str() {
+                            "EX" => *duration = Some(Duration::seconds(time_value)),
+                            "PX" => *duration = Some(Duration::milliseconds(time_value)),
+                            "EXAT" => {
+                                // Get the diff from now, and set the duration
+                                let diff_seconds = Utc::now().timestamp() - time_value;
+                                *duration = Some(Duration::seconds(diff_seconds))
+                            }
+                            "PXAT" => {
+                                // Convert to seconds, and then assign the duration
+                                let diff_seconds = Utc::now().timestamp() - (time_value / 1000);
+                                *duration = Some(Duration::seconds(diff_seconds))
+                            }
+                            _ => {}
+                        }
+                        return Ok(());
+                    }
+                }
+            }
         }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -9,8 +9,8 @@ use tokio::net::TcpStream;
 /// work.
 ///
 /// Current workaround is to have `mockall` as a
-/// dependency, as I wasn't able to have `mockall` 
-/// as a dev-dependency and also import the Mocked 
+/// dependency, as I wasn't able to have `mockall`
+/// as a dev-dependency and also import the Mocked
 /// instances in the tests/ dir
 ///
 /// "those in a tests directory, behave like independent crates that use your main library.

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -1,4 +1,5 @@
 use crate::cmd::ParseError;
+use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use mockall::automock;
 use std::{
@@ -7,6 +8,7 @@ use std::{
 };
 
 #[automock]
+#[async_trait]
 pub trait SharedStoreBase: Send + Sync {
     fn set(
         &self,
@@ -18,6 +20,8 @@ pub trait SharedStoreBase: Send + Sync {
     ) -> Result<Option<DataType>, ParseError>;
 
     fn get(&self, key: String) -> Option<DataType>;
+
+    async fn purge_expired_keys(&self);
 }
 
 /// Shared Data Store across all the connections
@@ -84,6 +88,7 @@ impl SharedStore {
     }
 }
 
+#[async_trait]
 impl SharedStoreBase for SharedStore {
     /// Set the `value` associated with the `key`, and an expiration
     /// duration, if provided
@@ -179,5 +184,9 @@ impl SharedStoreBase for SharedStore {
                 return None;
             }
         }
+    }
+
+    async fn purge_expired_keys(&self) {
+        todo!()
     }
 }

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -204,7 +204,7 @@ impl GuardedDataStore {
                 let mut rng = rand::thread_rng();
                 // Get the iterator of the keys, of which have an expiry.
                 // Borrow the hashmap
-                let mut keys = mutex.date_time.keys();
+                let keys = mutex.date_time.keys();
 
                 // Get the random indices to collect, for checking purposes.
                 let num_keys = mutex.date_time.len();
@@ -216,13 +216,12 @@ impl GuardedDataStore {
                 let num_to_get = std::cmp::min(num_keys, KEY_EXPIRY_NUM_KEYS_TO_CHECK);
 
                 let indices = sample(&mut rng, num_keys, num_to_get);
-
                 // Cloning the individual key is necessary, otherwise we'll still have borrowed the
                 // reference, and wouldn't be able to perform a mutable operation on the HashMap
                 // via mutex.data.remove(...)
                 random_keys = indices
                     .iter()
-                    .map(|i| keys.nth(i).unwrap().clone())
+                    .map(|i| keys.clone().nth(i).unwrap().clone())
                     .collect();
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,5 @@ pub mod server;
 
 pub const DEFAULT_HOST: &str = "127.0.0.1";
 pub const DEFAULT_PORT: u16 = 6666;
+pub const KEY_EXPIRY_DELAY_MS: u64 = 100;
+pub const KEY_EXPIRY_NUM_KEYS_TO_CHECK: usize = 20;


### PR DESCRIPTION
This PR introduces the following:

- [x] Key Expiry Parsing for SET command (EX, PX, EXAT and PXAT)
- [x] Passive Key Expiry via GET command
- [x] Key Expiration Algorithm, which runs every N seconds in the background
- [x] Expands on the existing test suite, from the [previous pull request](https://github.com/SaadKaleem/redust/pull/8#:~:text=Unit%20tests%20for%20the%20execution%20of%20the%20following%20commands%20with%20Mocking%20of%20Connection%20and%20SharedDataStore%3A) by adding key_expiry for SET into Integration tests.