### PR TITLE
Feature: More commands (EXISTS, DEL etc...)

### DIFF
--- a/src/cmd/decr.rs
+++ b/src/cmd/decr.rs
@@ -4,7 +4,7 @@ use crate::{ConnectionBase, RESPType, SharedStoreBase};
 /// The DECR operation in Redis
 #[derive(Debug)]
 pub struct Decr {
-    // The keys to check if they exist
+    // The key to decrement
     key: String,
 }
 

--- a/src/cmd/decr.rs
+++ b/src/cmd/decr.rs
@@ -1,0 +1,52 @@
+use crate::cmd::ParseError;
+use crate::{ConnectionBase, RESPType, SharedStoreBase};
+
+/// The DECR operation in Redis
+#[derive(Debug)]
+pub struct Decr {
+    // The keys to check if they exist
+    key: String,
+}
+
+impl Decr {
+    /// Create a new `DECR` command
+    pub fn new(key: String) -> Decr {
+        Decr { key }
+    }
+
+    /// Parsing the necessary arguments for the `DECR` command
+    ///
+    /// Syntax:
+    /// DECR key
+    pub fn parse(cmd_strings: Vec<String>) -> Result<Decr, ParseError> {
+        if cmd_strings.len() != 2 {
+            return Err(ParseError::SyntaxError(
+                "ERR wrong number of arguments for 'decr' command".to_string(),
+            ));
+        } else {
+            Ok(Decr::new(cmd_strings[1].clone()))
+        }
+    }
+
+    /// Execute the `Decr` command
+    ///
+    /// Returns an integer reply, for the number of keys
+    /// that exist from the specified arguments
+    pub async fn execute(
+        self,
+        shared_store: &dyn SharedStoreBase,
+        cnxn: &mut dyn ConnectionBase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Set the key:value in the shared store
+        let result = shared_store.decr(self.key);
+
+        let response = match result {
+            Ok(val) => RESPType::Integer(val),
+            Err(err) => RESPType::Error(err.to_string()),
+        };
+
+        cnxn.write_frame(&response).await?;
+
+        Ok(())
+    }
+}

--- a/src/cmd/decr.rs
+++ b/src/cmd/decr.rs
@@ -37,7 +37,7 @@ impl Decr {
         shared_store: &dyn SharedStoreBase,
         cnxn: &mut dyn ConnectionBase,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // Set the key:value in the shared store
+        // Decr the key:value in the shared store
         let result = shared_store.decr(self.key);
 
         let response = match result {

--- a/src/cmd/del.rs
+++ b/src/cmd/del.rs
@@ -1,0 +1,51 @@
+use crate::cmd::ParseError;
+use crate::{ConnectionBase, RESPType, SharedStoreBase};
+
+/// The DEL operation in Redis
+#[derive(Debug)]
+pub struct Del {
+    // The keys to check if they exist
+    keys: Vec<String>,
+}
+
+impl Del {
+    /// Create a new `DEL` command
+    pub fn new(keys: Vec<String>) -> Del {
+        Del { keys }
+    }
+
+    /// Parsing the necessary arguments for the `DEL` command
+    ///
+    /// Syntax:
+    /// DEL key [key ...]
+    pub fn parse(cmd_strings: Vec<String>) -> Result<Del, ParseError> {
+        if cmd_strings.len() < 2 {
+            return Err(ParseError::SyntaxError(
+                "ERR wrong number of arguments for 'del' command".to_string(),
+            ));
+        } else {
+            let keys = cmd_strings[1..].to_vec();
+
+            Ok(Del::new(keys))
+        }
+    }
+
+    /// Execute the `Del` command
+    ///
+    /// Returns an integer reply, for the number of keys
+    /// that exist from the specified arguments
+    pub async fn execute(
+        self,
+        shared_store: &dyn SharedStoreBase,
+        cnxn: &mut dyn ConnectionBase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Set the key:value in the shared store
+        let result: u64 = shared_store.del(self.keys);
+
+        let response = RESPType::Integer(result as i64);
+
+        cnxn.write_frame(&response).await?;
+
+        Ok(())
+    }
+}

--- a/src/cmd/exists.rs
+++ b/src/cmd/exists.rs
@@ -1,0 +1,51 @@
+use crate::cmd::ParseError;
+use crate::{ConnectionBase, RESPType, SharedStoreBase};
+
+/// The EXISTS operation in Redis
+#[derive(Debug)]
+pub struct Exists {
+    // The keys to check if they exist
+    keys: Vec<String>,
+}
+
+impl Exists {
+    /// Create a new `Exists` command
+    pub fn new(keys: Vec<String>) -> Exists {
+        Exists { keys }
+    }
+
+    /// Parsing the necessary arguments for the `Exists` command
+    ///
+    /// Syntax:
+    /// EXISTS key [key ...]
+    pub fn parse(cmd_strings: Vec<String>) -> Result<Exists, ParseError> {
+        if cmd_strings.len() < 2 {
+            return Err(ParseError::SyntaxError(
+                "ERR wrong number of arguments for 'exists' command".to_string(),
+            ));
+        } else {
+            let keys = cmd_strings[1..].to_vec();
+
+            Ok(Exists::new(keys))
+        }
+    }
+
+    /// Execute the `Exists` command
+    ///
+    /// Returns an integer reply, for the number of keys
+    /// that exist from the specified arguments
+    pub async fn execute(
+        self,
+        shared_store: &dyn SharedStoreBase,
+        cnxn: &mut dyn ConnectionBase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Set the key:value in the shared store
+        let result: u64 = shared_store.exists(self.keys);
+
+        let response = RESPType::Integer(result as i64);
+
+        cnxn.write_frame(&response).await?;
+
+        Ok(())
+    }
+}

--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -54,7 +54,7 @@ impl Get {
                         prefix_length,
                     }))
                 }
-                _ => RESPType::BulkString(None),
+                _ => RESPType::Error("ERR Wrong key type".to_string()),
             },
             // Return a nil bulk, if key isn't found
             None => RESPType::BulkString(None),

--- a/src/cmd/incr.rs
+++ b/src/cmd/incr.rs
@@ -37,7 +37,7 @@ impl Incr {
         shared_store: &dyn SharedStoreBase,
         cnxn: &mut dyn ConnectionBase,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // Set the key:value in the shared store
+        // Incr the key:value in the shared store
         let result = shared_store.incr(self.key);
 
         let response = match result {

--- a/src/cmd/incr.rs
+++ b/src/cmd/incr.rs
@@ -1,0 +1,52 @@
+use crate::cmd::ParseError;
+use crate::{ConnectionBase, RESPType, SharedStoreBase};
+
+/// The INCR operation in Redis
+#[derive(Debug)]
+pub struct Incr {
+    // The keys to check if they exist
+    key: String,
+}
+
+impl Incr {
+    /// Create a new `INCR` command
+    pub fn new(key: String) -> Incr {
+        Incr { key }
+    }
+
+    /// Parsing the necessary arguments for the `INCR` command
+    ///
+    /// Syntax:
+    /// INCR key
+    pub fn parse(cmd_strings: Vec<String>) -> Result<Incr, ParseError> {
+        if cmd_strings.len() != 2 {
+            return Err(ParseError::SyntaxError(
+                "ERR wrong number of arguments for 'incr' command".to_string(),
+            ));
+        } else {
+            Ok(Incr::new(cmd_strings[1].clone()))
+        }
+    }
+
+    /// Execute the `Incr` command
+    ///
+    /// Returns an integer reply, for the number of keys
+    /// that exist from the specified arguments
+    pub async fn execute(
+        self,
+        shared_store: &dyn SharedStoreBase,
+        cnxn: &mut dyn ConnectionBase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Set the key:value in the shared store
+        let result = shared_store.incr(self.key);
+
+        let response = match result {
+            Ok(val) => RESPType::Integer(val),
+            Err(err) => RESPType::Error(err.to_string()),
+        };
+
+        cnxn.write_frame(&response).await?;
+
+        Ok(())
+    }
+}

--- a/src/cmd/incr.rs
+++ b/src/cmd/incr.rs
@@ -4,7 +4,7 @@ use crate::{ConnectionBase, RESPType, SharedStoreBase};
 /// The INCR operation in Redis
 #[derive(Debug)]
 pub struct Incr {
-    // The keys to check if they exist
+    // The key to increment
     key: String,
 }
 

--- a/src/cmd/lpush.rs
+++ b/src/cmd/lpush.rs
@@ -36,8 +36,8 @@ impl Lpush {
 
     /// Execute the `Lpush` command
     ///
-    /// Returns an integer reply, for the number of keys
-    /// that exist from the specified arguments
+    /// Returns an integer reply, representing
+    /// the length of the list
     pub async fn execute(
         self,
         shared_store: &dyn SharedStoreBase,

--- a/src/cmd/lpush.rs
+++ b/src/cmd/lpush.rs
@@ -1,0 +1,58 @@
+use crate::cmd::ParseError;
+use crate::{ConnectionBase, RESPType, SharedStoreBase};
+
+/// The LPUSH operation in Redis
+#[derive(Debug)]
+pub struct Lpush {
+    // The keys to push at
+    key: String,
+
+    // The elements to push
+    elements: Vec<String>,
+}
+
+impl Lpush {
+    /// Create a new `LPUSH` command
+    pub fn new(key: String, elements: Vec<String>) -> Lpush {
+        Lpush { key, elements }
+    }
+
+    /// Parsing the necessary arguments for the `LPUSH` command
+    ///
+    /// Syntax:
+    /// LPUSH key
+    pub fn parse(cmd_strings: Vec<String>) -> Result<Lpush, ParseError> {
+        if cmd_strings.len() < 3 {
+            return Err(ParseError::SyntaxError(
+                "ERR wrong number of arguments for 'lpush' command".to_string(),
+            ));
+        } else {
+            Ok(Lpush::new(
+                cmd_strings[1].clone(),
+                cmd_strings[2..].to_vec(),
+            ))
+        }
+    }
+
+    /// Execute the `Lpush` command
+    ///
+    /// Returns an integer reply, for the number of keys
+    /// that exist from the specified arguments
+    pub async fn execute(
+        self,
+        shared_store: &dyn SharedStoreBase,
+        cnxn: &mut dyn ConnectionBase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Set the key:value in the shared store
+        let result = shared_store.lpush(self.key, self.elements);
+
+        let response = match result {
+            Ok(val) => RESPType::Integer(val),
+            Err(err) => RESPType::Error(err.to_string()),
+        };
+
+        cnxn.write_frame(&response).await?;
+
+        Ok(())
+    }
+}

--- a/src/cmd/lpush.rs
+++ b/src/cmd/lpush.rs
@@ -43,7 +43,7 @@ impl Lpush {
         shared_store: &dyn SharedStoreBase,
         cnxn: &mut dyn ConnectionBase,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // Set the key:value in the shared store
+        // Push the elements in the shared store
         let result = shared_store.lpush(self.key, self.elements);
 
         let response = match result {

--- a/src/cmd/lrange.rs
+++ b/src/cmd/lrange.rs
@@ -1,0 +1,97 @@
+use crate::cmd::ParseError;
+use crate::protocol_handler::BulkStringData;
+use crate::{ConnectionBase, RESPType, SharedStoreBase};
+
+/// The LRANGE operation in Redis
+#[derive(Debug)]
+pub struct Lrange {
+    // The key to query, which represents a List
+    key: String,
+
+    // The start index
+    start: i64,
+
+    // The stop index (inclusive)
+    stop: i64,
+}
+
+impl Lrange {
+    /// Create a new `LRANGE` command
+    pub fn new(key: String, start: i64, stop: i64) -> Lrange {
+        Lrange { key, start, stop }
+    }
+
+    /// Parsing the necessary arguments for the `LRANGE` command
+    ///
+    /// Syntax:
+    /// LRANGE key
+    pub fn parse(cmd_strings: Vec<String>) -> Result<Lrange, ParseError> {
+        if cmd_strings.len() != 4 {
+            return Err(ParseError::SyntaxError(
+                "ERR wrong number of arguments for 'lrange' command".to_string(),
+            ));
+        } else {
+            let start: i64;
+            let stop: i64;
+
+            match cmd_strings[2].parse::<i64>() {
+                Ok(val) => {
+                    start = val;
+                }
+                Err(_) => {
+                    return Err(ParseError::SyntaxError(
+                        "ERR start index is not an integer".to_string(),
+                    ));
+                }
+            }
+
+            match cmd_strings[3].parse::<i64>() {
+                Ok(val) => {
+                    stop = val;
+                }
+                Err(_) => {
+                    return Err(ParseError::SyntaxError(
+                        "ERR stop index is not an integer".to_string(),
+                    ));
+                }
+            }
+
+            Ok(Lrange::new(cmd_strings[1].clone(), start, stop))
+        }
+    }
+
+    /// Execute the `Lrange` command
+    ///
+    /// Returns the elements, as an Array which are part of the
+    /// provided indices
+    pub async fn execute(
+        self,
+        shared_store: &dyn SharedStoreBase,
+        cnxn: &mut dyn ConnectionBase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Query the `key` for the elements
+        let result = shared_store.lrange(self.key, self.start, self.stop);
+
+        let response = match result {
+            Ok(string_vec) => {
+                // Convert Vec<String> to Vec<RESPType of Bulk Strings>
+                let bulk_strings: Vec<RESPType> = string_vec
+                    .iter()
+                    .map(|s| {
+                        RESPType::BulkString(Some(BulkStringData {
+                            text: s.to_string(),
+                            prefix_length: s.len() as usize,
+                        }))
+                    })
+                    .collect();
+
+                RESPType::Array(bulk_strings)
+            }
+            Err(err) => RESPType::Error(err.to_string()),
+        };
+
+        cnxn.write_frame(&response).await?;
+
+        Ok(())
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -10,6 +10,9 @@ pub use set::Set;
 mod get;
 pub use get::Get;
 
+mod exists;
+pub use exists::Exists;
+
 use crate::{Connection, RESPType, SharedStore};
 use std::fmt;
 
@@ -21,6 +24,7 @@ pub enum Command {
     Echo(Echo),
     Set(Set),
     Get(Get),
+    Exists(Exists),
 }
 
 #[derive(Debug)]
@@ -76,6 +80,7 @@ impl Command {
             "echo" => Command::Echo(Echo::parse(cmd_strings)?),
             "set" => Command::Set(Set::parse(cmd_strings)?),
             "get" => Command::Get(Get::parse(cmd_strings)?),
+            "exists" => Command::Exists(Exists::parse(cmd_strings)?),
             _ => {
                 return Err(ParseError::UnrecognizedCmd(format!(
                     "unknown command '{}'",
@@ -112,6 +117,7 @@ impl Command {
             Command::Echo(cmd) => cmd.execute(cnxn).await,
             Command::Set(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Get(cmd) => cmd.execute(shared_store, cnxn).await,
+            Command::Exists(cmd) => cmd.execute(shared_store, cnxn).await,
         }
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -22,6 +22,9 @@ pub use incr::Incr;
 mod decr;
 pub use decr::Decr;
 
+mod lpush;
+pub use lpush::Lpush;
+
 use crate::{Connection, RESPType, SharedStore};
 use std::fmt;
 
@@ -37,6 +40,7 @@ pub enum Command {
     Del(Del),
     Incr(Incr),
     Decr(Decr),
+    Lpush(Lpush),
 }
 
 #[derive(Debug)]
@@ -96,6 +100,7 @@ impl Command {
             "del" => Command::Del(Del::parse(cmd_strings)?),
             "incr" => Command::Incr(Incr::parse(cmd_strings)?),
             "decr" => Command::Decr(Decr::parse(cmd_strings)?),
+            "lpush" => Command::Lpush(Lpush::parse(cmd_strings)?),
             _ => {
                 return Err(ParseError::UnrecognizedCmd(format!(
                     "unknown command '{}'",
@@ -136,6 +141,7 @@ impl Command {
             Command::Del(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Incr(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Decr(cmd) => cmd.execute(shared_store, cnxn).await,
+            Command::Lpush(cmd) => cmd.execute(shared_store, cnxn).await,
         }
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -28,6 +28,9 @@ pub use lpush::Lpush;
 mod lrange;
 pub use lrange::Lrange;
 
+mod rpush;
+pub use rpush::Rpush;
+
 use crate::{Connection, RESPType, SharedStore};
 use std::fmt;
 
@@ -45,6 +48,7 @@ pub enum Command {
     Decr(Decr),
     Lpush(Lpush),
     Lrange(Lrange),
+    Rpush(Rpush),
 }
 
 #[derive(Debug)]
@@ -106,6 +110,7 @@ impl Command {
             "decr" => Command::Decr(Decr::parse(cmd_strings)?),
             "lpush" => Command::Lpush(Lpush::parse(cmd_strings)?),
             "lrange" => Command::Lrange(Lrange::parse(cmd_strings)?),
+            "rpush" => Command::Rpush(Rpush::parse(cmd_strings)?),
             _ => {
                 return Err(ParseError::UnrecognizedCmd(format!(
                     "unknown command '{}'",
@@ -148,6 +153,7 @@ impl Command {
             Command::Decr(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Lpush(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Lrange(cmd) => cmd.execute(shared_store, cnxn).await,
+            Command::Rpush(cmd) => cmd.execute(shared_store, cnxn).await,
         }
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -13,6 +13,9 @@ pub use get::Get;
 mod exists;
 pub use exists::Exists;
 
+mod del;
+pub use del::Del;
+
 use crate::{Connection, RESPType, SharedStore};
 use std::fmt;
 
@@ -25,6 +28,7 @@ pub enum Command {
     Set(Set),
     Get(Get),
     Exists(Exists),
+    Del(Del),
 }
 
 #[derive(Debug)]
@@ -81,6 +85,7 @@ impl Command {
             "set" => Command::Set(Set::parse(cmd_strings)?),
             "get" => Command::Get(Get::parse(cmd_strings)?),
             "exists" => Command::Exists(Exists::parse(cmd_strings)?),
+            "del" => Command::Del(Del::parse(cmd_strings)?),
             _ => {
                 return Err(ParseError::UnrecognizedCmd(format!(
                     "unknown command '{}'",
@@ -118,6 +123,7 @@ impl Command {
             Command::Set(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Get(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Exists(cmd) => cmd.execute(shared_store, cnxn).await,
+            Command::Del(cmd) => cmd.execute(shared_store, cnxn).await,
         }
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -19,6 +19,9 @@ pub use del::Del;
 mod incr;
 pub use incr::Incr;
 
+mod decr;
+pub use decr::Decr;
+
 use crate::{Connection, RESPType, SharedStore};
 use std::fmt;
 
@@ -33,6 +36,7 @@ pub enum Command {
     Exists(Exists),
     Del(Del),
     Incr(Incr),
+    Decr(Decr),
 }
 
 #[derive(Debug)]
@@ -91,6 +95,7 @@ impl Command {
             "exists" => Command::Exists(Exists::parse(cmd_strings)?),
             "del" => Command::Del(Del::parse(cmd_strings)?),
             "incr" => Command::Incr(Incr::parse(cmd_strings)?),
+            "decr" => Command::Decr(Decr::parse(cmd_strings)?),
             _ => {
                 return Err(ParseError::UnrecognizedCmd(format!(
                     "unknown command '{}'",
@@ -130,6 +135,7 @@ impl Command {
             Command::Exists(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Del(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Incr(cmd) => cmd.execute(shared_store, cnxn).await,
+            Command::Decr(cmd) => cmd.execute(shared_store, cnxn).await,
         }
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -16,6 +16,9 @@ pub use exists::Exists;
 mod del;
 pub use del::Del;
 
+mod incr;
+pub use incr::Incr;
+
 use crate::{Connection, RESPType, SharedStore};
 use std::fmt;
 
@@ -29,6 +32,7 @@ pub enum Command {
     Get(Get),
     Exists(Exists),
     Del(Del),
+    Incr(Incr),
 }
 
 #[derive(Debug)]
@@ -86,6 +90,7 @@ impl Command {
             "get" => Command::Get(Get::parse(cmd_strings)?),
             "exists" => Command::Exists(Exists::parse(cmd_strings)?),
             "del" => Command::Del(Del::parse(cmd_strings)?),
+            "incr" => Command::Incr(Incr::parse(cmd_strings)?),
             _ => {
                 return Err(ParseError::UnrecognizedCmd(format!(
                     "unknown command '{}'",
@@ -124,6 +129,7 @@ impl Command {
             Command::Get(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Exists(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Del(cmd) => cmd.execute(shared_store, cnxn).await,
+            Command::Incr(cmd) => cmd.execute(shared_store, cnxn).await,
         }
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -25,6 +25,9 @@ pub use decr::Decr;
 mod lpush;
 pub use lpush::Lpush;
 
+mod lrange;
+pub use lrange::Lrange;
+
 use crate::{Connection, RESPType, SharedStore};
 use std::fmt;
 
@@ -41,6 +44,7 @@ pub enum Command {
     Incr(Incr),
     Decr(Decr),
     Lpush(Lpush),
+    Lrange(Lrange),
 }
 
 #[derive(Debug)]
@@ -101,6 +105,7 @@ impl Command {
             "incr" => Command::Incr(Incr::parse(cmd_strings)?),
             "decr" => Command::Decr(Decr::parse(cmd_strings)?),
             "lpush" => Command::Lpush(Lpush::parse(cmd_strings)?),
+            "lrange" => Command::Lrange(Lrange::parse(cmd_strings)?),
             _ => {
                 return Err(ParseError::UnrecognizedCmd(format!(
                     "unknown command '{}'",
@@ -142,6 +147,7 @@ impl Command {
             Command::Incr(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Decr(cmd) => cmd.execute(shared_store, cnxn).await,
             Command::Lpush(cmd) => cmd.execute(shared_store, cnxn).await,
+            Command::Lrange(cmd) => cmd.execute(shared_store, cnxn).await,
         }
     }
 }

--- a/src/cmd/rpush.rs
+++ b/src/cmd/rpush.rs
@@ -1,0 +1,58 @@
+use crate::cmd::ParseError;
+use crate::{ConnectionBase, RESPType, SharedStoreBase};
+
+/// The RPUSH operation in Redis
+#[derive(Debug)]
+pub struct Rpush {
+    // The keys to push at
+    key: String,
+
+    // The elements to push
+    elements: Vec<String>,
+}
+
+impl Rpush {
+    /// Create a new `RPUSH` command
+    pub fn new(key: String, elements: Vec<String>) -> Rpush {
+        Rpush { key, elements }
+    }
+
+    /// Parsing the necessary arguments for the `RPUSH` command
+    ///
+    /// Syntax:
+    /// RPUSH key
+    pub fn parse(cmd_strings: Vec<String>) -> Result<Rpush, ParseError> {
+        if cmd_strings.len() < 3 {
+            return Err(ParseError::SyntaxError(
+                "ERR wrong number of arguments for 'rpush' command".to_string(),
+            ));
+        } else {
+            Ok(Rpush::new(
+                cmd_strings[1].clone(),
+                cmd_strings[2..].to_vec(),
+            ))
+        }
+    }
+
+    /// Execute the `Rpush` command
+    ///
+    /// Returns an integer reply, representing
+    /// the length of the list
+    pub async fn execute(
+        self,
+        shared_store: &dyn SharedStoreBase,
+        cnxn: &mut dyn ConnectionBase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Push the elements in the shared store
+        let result = shared_store.rpush(self.key, self.elements);
+
+        let response = match result {
+            Ok(val) => RESPType::Integer(val),
+            Err(err) => RESPType::Error(err.to_string()),
+        };
+
+        cnxn.write_frame(&response).await?;
+
+        Ok(())
+    }
+}

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -24,6 +24,8 @@ pub trait SharedStoreBase: Send + Sync {
     fn del(&self, keys: Vec<String>) -> u64;
 
     fn incr(&self, key: String) -> Result<i64, ParseError>;
+
+    fn decr(&self, key: String) -> Result<i64, ParseError>;
 }
 
 /// Shared Data Store across all the connections
@@ -88,7 +90,7 @@ impl SharedStore {
         SharedStore { shared }
     }
 
-    /// Adjust the `key` by the `amount`, this can be used to increment or decrement 
+    /// Adjust the `key` by the `amount`, this can be used to increment or decrement
     /// the `value` at `key`
     pub fn _adjust_by(
         &self,
@@ -261,5 +263,12 @@ impl SharedStoreBase for SharedStore {
         let mut mutex: std::sync::MutexGuard<'_, DataStore> = self.shared.store.lock().unwrap();
 
         return self._adjust_by(&mut mutex, &key, 1);
+    }
+
+    fn decr(&self, key: String) -> Result<i64, ParseError> {
+        // Acquire the Mutex
+        let mut mutex: std::sync::MutexGuard<'_, DataStore> = self.shared.store.lock().unwrap();
+
+        return self._adjust_by(&mut mutex, &key, -1);
     }
 }

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -223,6 +223,9 @@ impl SharedStoreBase for SharedStore {
         }
     }
 
+    /// Check if the provided `keys` are part of the HashMap
+    ///
+    /// Will return a `u64` integer count of the number of keys, that exist.
     fn exists(&self, keys: Vec<String>) -> u64 {
         // Acquire the Mutex
         let mutex: std::sync::MutexGuard<'_, DataStore> = self.shared.store.lock().unwrap();
@@ -238,6 +241,9 @@ impl SharedStoreBase for SharedStore {
         count
     }
 
+    /// Delete the provided `keys`
+    ///
+    /// Will return a `u64` integer count of the number of keys, that were successfully deleted
     fn del(&self, keys: Vec<String>) -> u64 {
         // Acquire the Mutex
         let mut mutex: std::sync::MutexGuard<'_, DataStore> = self.shared.store.lock().unwrap();
@@ -258,6 +264,10 @@ impl SharedStoreBase for SharedStore {
         count
     }
 
+    /// Increment the provided `key`, given it's parsable to a signed integer (i64) type.
+    /// If the key didn't exist, the value is started from zero, and incremented.
+    /// 
+    /// Will return the new incremented i64 integer value.
     fn incr(&self, key: String) -> Result<i64, ParseError> {
         // Acquire the Mutex
         let mut mutex: std::sync::MutexGuard<'_, DataStore> = self.shared.store.lock().unwrap();
@@ -265,6 +275,10 @@ impl SharedStoreBase for SharedStore {
         return self._adjust_by(&mut mutex, &key, 1);
     }
 
+    /// Decrement the provided `key`, given it's parsable to an signed integer (i64) type.
+    /// If the key didn't exist, the value is started from zero, and decremented.
+    /// 
+    /// Will return the new decremented i64 integer value.
     fn decr(&self, key: String) -> Result<i64, ParseError> {
         // Acquire the Mutex
         let mut mutex: std::sync::MutexGuard<'_, DataStore> = self.shared.store.lock().unwrap();

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -74,6 +74,8 @@ pub struct DataStore {
 #[derive(Debug, Clone, PartialEq)]
 pub enum DataType {
     String(String),
+
+    // Needs to be behind a RefCell, to mutate in-place.
     LinkedList(RefCell<LinkedList<String>>),
 }
 

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -126,7 +126,7 @@ impl SharedStore {
                     ));
                 }
             },
-            // Key:Val didn't exist, so set it as 0+1=1
+            // Key:Val didn't exist
             None => {
                 let value: i64 = amount;
                 mutex

--- a/src/data_store.rs
+++ b/src/data_store.rs
@@ -18,6 +18,8 @@ pub trait SharedStoreBase: Send + Sync {
     ) -> Result<Option<DataType>, ParseError>;
 
     fn get(&self, key: String) -> Option<DataType>;
+
+    fn exists(&self, keys: Vec<String>) -> u64;
 }
 
 /// Shared Data Store across all the connections
@@ -166,5 +168,20 @@ impl SharedStoreBase for SharedStore {
                 return None;
             }
         }
+    }
+
+    fn exists(&self, keys: Vec<String>) -> u64 {
+        // Acquire the Mutex
+        let mutex: std::sync::MutexGuard<'_, DataStore> = self.shared.store.lock().unwrap();
+
+        let mut count: u64 = 0;
+
+        for k in keys {
+            if mutex.data.contains_key(&k) == true {
+                count += 1;
+            }
+        }
+
+        count
     }
 }

--- a/src/protocol_handler.rs
+++ b/src/protocol_handler.rs
@@ -8,7 +8,7 @@ const MSG_SEPERATOR_SIZE: usize = MSG_SEPERATOR.len();
 pub enum RESPType {
     SimpleString(String),
     Error(String),
-    Integer(i32),
+    Integer(i64),
     BulkString(Option<BulkStringData>),
     Array(Vec<RESPType>),
 }
@@ -141,7 +141,7 @@ impl BaseSerializer for IntegerSerializer {
 
         if let Some(position) = separator {
             // The separator was found
-            let payload: Result<i32, _> = String::from_utf8_lossy(&buffer[1..position]).parse();
+            let payload: Result<i64, _> = String::from_utf8_lossy(&buffer[1..position]).parse();
 
             match payload {
                 Ok(integer) => {


### PR DESCRIPTION
This PR introduces the following commands:

- [x] [EXISTS](https://redis.io/commands/exists/) - check if a key is present.
- [x] [DEL](https://redis.io/commands/del/) - delete one or more keys.
- [x] [INCR](https://redis.io/commands/incr/) - increment a stored number by one.
- [x] [DECR](https://redis.io/commands/decr/) - decrement a stored number by one.
- [x] [LPUSH](https://redis.io/commands/lpush/) - insert all the values at the head of a list.
- [x] [RPUSH](https://redis.io/commands/rpush/) - insert all the values at the tail of a list.
- [x] [LRANGE](https://redis.io/commands/lrange/) - query the specified elements of a list. The offsets start and stop are zero-based indexes



---

Benchmark of LPUSH & LRANGE:

Baseline Benchmark (Official Redis 7.0.6)

```
LPUSH (needed to benchmark LRANGE): 129466.60 requests per second, p50=0.183 msec                    
LRANGE_100 (first 100 elements): 66538.02 requests per second, p50=0.367 msec                   
LRANGE_300 (first 300 elements): 23456.56 requests per second, p50=0.975 msec                   
LRANGE_500 (first 500 elements): 15453.56 requests per second, p50=1.463 msec                   
LRANGE_600 (first 600 elements): 13393.51 requests per second, p50=1.695 msec
```

Our Benchmark Summary:

```
LPUSH (needed to benchmark LRANGE): 103071.54 requests per second, p50=0.263 msec
LRANGE_100 (first 100 elements): 46939.54 requests per second, p50=0.607 msec
LRANGE_300 (first 300 elements): 19514.10 requests per second, p50=1.423 msec
LRANGE_500 (first 500 elements): 12847.86 requests per second, p50=2.151 msec
LRANGE_600 (first 600 elements): 10925.50 requests per second, p50=2.503 msec
```